### PR TITLE
Add very simple style for file 'buildings.shp'

### DIFF
--- a/styles/openstreetmap/geofabrik/buildings.qml
+++ b/styles/openstreetmap/geofabrik/buildings.qml
@@ -1,0 +1,63 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="1.8.0-Lisboa" minimumScale="0" maximumScale="5000" hasScaleBasedVisibilityFlag="1">
+  <transparencyLevelInt>255</transparencyLevelInt>
+  <renderer-v2 symbollevels="0" type="singleSymbol">
+    <symbols>
+      <symbol outputUnit="MM" alpha="1" type="fill" name="0">
+        <layer pass="0" class="SimpleFill" locked="0">
+          <prop k="color" v="170,170,170,255"/>
+          <prop k="color_border" v="0,0,0,255"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="style" v="solid"/>
+          <prop k="style_border" v="no"/>
+          <prop k="width_border" v="0.26"/>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation field=""/>
+    <sizescale field=""/>
+  </renderer-v2>
+  <customproperties/>
+  <displayfield>name</displayfield>
+  <label>0</label>
+  <labelattributes>
+    <label fieldname="" text="Label"/>
+    <family fieldname="" name="MS Shell Dlg 2"/>
+    <size fieldname="" units="pt" value="12"/>
+    <bold fieldname="" on="0"/>
+    <italic fieldname="" on="0"/>
+    <underline fieldname="" on="0"/>
+    <strikeout fieldname="" on="0"/>
+    <color fieldname="" red="0" blue="0" green="0"/>
+    <x fieldname=""/>
+    <y fieldname=""/>
+    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
+    <angle fieldname="" value="0" auto="0"/>
+    <alignment fieldname="" value="center"/>
+    <buffercolor fieldname="" red="255" blue="255" green="255"/>
+    <buffersize fieldname="" units="pt" value="1"/>
+    <bufferenabled fieldname="" on=""/>
+    <multilineenabled fieldname="" on=""/>
+    <selectedonly on=""/>
+  </labelattributes>
+  <edittypes>
+    <edittype type="0" name="name"/>
+    <edittype type="0" name="osm_id"/>
+    <edittype type="0" name="type"/>
+  </edittypes>
+  <editform>.</editform>
+  <editforminit></editforminit>
+  <annotationform>.</annotationform>
+  <attributeactions/>
+  <overlay display="false" type="diagram">
+    <renderer item_interpretation="linear">
+      <diagramitem size="0" value="0"/>
+      <diagramitem size="0" value="0"/>
+    </renderer>
+    <factory sizeUnits="MM" type="Pie">
+      <wellknownname>Pie</wellknownname>
+      <classificationfield>0</classificationfield>
+    </factory>
+    <scalingAttribute>0</scalingAttribute>
+  </overlay>
+</qgis>


### PR DESCRIPTION
At least for Denmark Geofabrik includes buildings in a file called 'buildings.shp'. (See http://download.geofabrik.de/europe/denmark-latest.shp.zip). I just added an extremely simple style for these. 
![image](https://f.cloud.github.com/assets/1392735/366252/f29bf95c-a27b-11e2-86c0-6a0b2802f33f.png)
